### PR TITLE
Ignore options set to undefined or null

### DIFF
--- a/lib/runGruntfile.js
+++ b/lib/runGruntfile.js
@@ -103,9 +103,9 @@ function runGruntfile(grunt, src, tasks, options, callback) {
 		if (opt.length === 0) {
 			argArr.push(value);
 		}
-		else {
+		else if (!_.isUndefined(value) && !_.isNull(value)) {
 			argArr.push((opt.length === 1 ? '-' : '--') + opt);
-			if (value !== true && !(_.isNull(value) && _.isUndefined(value))) {
+			if (value !== true) {
 				argArr.push(value);
 			}
 		}


### PR DESCRIPTION
We will be using the following pattern in initConfig to pass certain options passed via commandline to the called grunt file. Doing this with the current code causes options not passed at all to be forwarded as flags. This pull request ignores null and undefined values. If you have any alternatives on how to achieve this please let me know.

```js
run_grunt: {
  gruntOptions: {
    test: grunt.option('test'),
    chunk: grunt.option('chunk')
  },
  ...
}
```
