### PR TITLE
Construct argument using "gruntOption"

### DIFF
--- a/lib/runGruntfile.js
+++ b/lib/runGruntfile.js
@@ -104,10 +104,14 @@ function runGruntfile(grunt, src, tasks, options, callback) {
 			argArr.push(value);
 		}
 		else {
-			argArr.push((opt.length === 1 ? '-' : '--') + opt);
+			var option = (opt.length === 1 ? '-' : '--') + opt;
+			argArr.push(option);
+
+			// append value if passed as an option
 			if (value !== true && !(_.isNull(value) && _.isUndefined(value))) {
-				argArr.push(value);
+				option = option + '=' + value;
 			}
+			argArr.push(option);
 		}
 	});
 


### PR DESCRIPTION
"=" sign is missing between key and value of an argument to grunt.
Thus each option is considered as task.

This commit will construct argument correctly to avoid the above issue

Signed-off-by: Sanjiv Krishnasamy <sanjiv@ti.com>